### PR TITLE
FR_1261

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.3.RELEASE'
     id 'info.solidsoft.pitest' version '1.3.0'
     id 'jacoco'
-    id 'org.owasp.dependencycheck' version '4.0.2'
+    id 'org.owasp.dependencycheck' version '5.1.0'
     id 'org.sonarqube' version '2.6.2'
     id 'org.springframework.boot' version '2.1.3.RELEASE'
     id 'pmd'

--- a/src/main/java/uk/gov/hmcts/reform/emclient/exception/InvalidURIException.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/exception/InvalidURIException.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.emclient.exception;
+
+public class InvalidURIException extends RuntimeException {
+    private static final long serialVersionUID = 8758617259382387538L;
+
+    public InvalidURIException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/emclient/service/EvidenceManagementDownloadServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/emclient/service/EvidenceManagementDownloadServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.emclient.service;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -11,6 +12,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 @Service
 @Slf4j
@@ -29,6 +33,9 @@ public class EvidenceManagementDownloadServiceImpl implements EvidenceManagement
     @Autowired
     private AuthTokenGenerator authTokenGenerator;
 
+    @Value("${document.management.store.baseUrl}")
+    private String evidenceManagementUrl;
+
     @Override
     public ResponseEntity<byte[]> download(@NonNull final String binaryFileUrl) {
 
@@ -37,8 +44,15 @@ public class EvidenceManagementDownloadServiceImpl implements EvidenceManagement
         headers.set(SERVICE_AUTHORIZATION, authTokenGenerator.generate());
         headers.set(USER_ROLES, FINANCIAL_REMEDY_COURT_ADMIN);
         HttpEntity<Object> httpEntity = new HttpEntity<>(headers);
+        String url;
+        try {
+             url = getUrl(binaryFileUrl);
+        } catch (URISyntaxException e) {
+            log.error("Failed to rewrite the url for document for {}", binaryFileUrl);
+            throw new RuntimeException(String.format("Failed to rewrite the url for document for %s", binaryFileUrl));
+        }
 
-        ResponseEntity<byte[]> response = restTemplate.exchange(binaryFileUrl, HttpMethod.GET, httpEntity, byte[].class);
+        ResponseEntity<byte[]> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, byte[].class);
         if (response.getStatusCode() != HttpStatus.OK) {
             log.error("Failed to get bytes from document store for document {} ",
                 binaryFileUrl);
@@ -47,6 +61,12 @@ public class EvidenceManagementDownloadServiceImpl implements EvidenceManagement
 
         log.info("File download status : {} ", response.getStatusCode());
         return response;
+    }
+
+    private String getUrl(String binaryFileUrl) throws URISyntaxException {
+        URI uri = new URI(binaryFileUrl);
+        return evidenceManagementUrl + uri.getPath();
+
     }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -81,3 +81,5 @@ idam.api.url=${IDAM_API_URL:http://localhost:4501}
 
 documentation.swagger.enabled=${SWAGGER_ENABLED:true}
 
+document.management.store.baseUrl=${DOCUMENT_MANAGEMENT_STORE_URL:http://localhost:3405}
+

--- a/src/smokeTest/resources/application.properties
+++ b/src/smokeTest/resources/application.properties
@@ -36,3 +36,5 @@ endpoints.fileupload.extensions=.jpg,.jpeg,.bmp,.tif,.tiff,.png,.pdf
 endpoints.fileupload.mimetypes=image/jpeg,application/pdf,image/tiff,image/png,image/bmp
 
 documentation.swagger.enabled=true
+
+document.management.store.baseUrl=${DOCUMENT_MANAGEMENT_STORE_URL:http://localhost:3405}

--- a/src/test/java/uk/gov/hmcts/reform/emclient/service/EvidenceManagementDownloadServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/emclient/service/EvidenceManagementDownloadServiceImplTest.java
@@ -2,7 +2,10 @@ package uk.gov.hmcts.reform.emclient.service;
 
 
 import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -15,6 +18,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestTemplate;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.emclient.exception.InvalidURIException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -29,7 +33,10 @@ import static org.mockito.Mockito.when;
 public class EvidenceManagementDownloadServiceImplTest {
 
     private static final String EVIDENCE_MANAGEMENT_SERVICE_URL = "http://localhost:8080/documents/";
-    public static final String URL = "http://dm-store-demo.service.core-compute-demo.internal/";
+    private static final String URL = "http://dm-store-demo.service.core-compute-demo.internal/";
+
+    @ClassRule
+    public static ExpectedException expectedException = ExpectedException.none();
 
     @Mock
     private RestTemplate restTemplate;
@@ -85,6 +92,13 @@ public class EvidenceManagementDownloadServiceImplTest {
 
         ResponseEntity<?> response = downloadService.download(fileUrl);
         assertFalse("Failed to receive exception resulting from non-running EM service", true);
+    }
+
+
+    @Test(expected = InvalidURIException.class)
+    public void shouldPassThruExceptionThrownWhenInvalidURI() {
+        String fileUrl = "//><sssssss/>";
+        downloadService.download(fileUrl);
     }
 
     private void setupMockEvidenceManagementService(String fileUrl,


### PR DESCRIPTION
- Url rewriting with dm-store-url provided from the infrastructure as CaseDocument Url contains 443 internal port. It is a bug on CCD.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-1261

### Change description ###

 Url rewriting with dm-store-url  while downloading the file.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
